### PR TITLE
feat: improve fetch error handling with retries using typed-rest-client

### DIFF
--- a/buildAndReleaseTask/UseOpenTofuV0/__tests__/opentofu.test.ts
+++ b/buildAndReleaseTask/UseOpenTofuV0/__tests__/opentofu.test.ts
@@ -5,6 +5,14 @@ jest.mock('azure-pipelines-tool-lib/tool');
 jest.mock('fs');
 jest.mock('../utils');
 
+// Mock typed-rest-client/RestClient with a controllable get function
+const mockGet = jest.fn();
+jest.mock('typed-rest-client/RestClient', () => ({
+  RestClient: jest.fn().mockImplementation(() => ({
+    get: mockGet,
+  })),
+}));
+
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from 'azure-pipelines-tool-lib/tool';
 import * as path from 'path';
@@ -12,8 +20,12 @@ import * as fs from 'fs';
 import { getOpenTofuVersion, installOpenTofu, verifyInstall } from '../opentofu';
 import * as utils from '../utils';
 
-// Mock global fetch
-global.fetch = jest.fn();
+// Helper to create a mock RestClient response
+const createMockRestResponse = <T>(statusCode: number, result: T | null) => ({
+  statusCode,
+  result,
+  headers: {},
+});
 
 describe('opentofu', () => {
   beforeEach(() => {
@@ -58,10 +70,7 @@ describe('opentofu', () => {
     };
 
     it('should fetch and return the latest version', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => mockVersionData,
-      });
+      mockGet.mockResolvedValue(createMockRestResponse(200, mockVersionData));
 
       (tr.evaluateVersions as jest.Mock).mockReturnValue('1.10.2');
       (tl.debug as jest.Mock).mockImplementation(() => {});
@@ -71,7 +80,7 @@ describe('opentofu', () => {
 
       expect(result.version).toBe('1.10.2');
       expect(result.files).toEqual(mockVersionData.versions[0].files);
-      expect(global.fetch).toHaveBeenCalledWith('https://get.opentofu.org/tofu/api.json');
+      expect(mockGet).toHaveBeenCalledWith('https://get.opentofu.org/tofu/api.json');
       expect(tr.evaluateVersions).toHaveBeenCalledWith(
         ['1.10.2', '1.10.1', '1.9.0', '1.6.0'],
         '>1.0.0'
@@ -79,10 +88,7 @@ describe('opentofu', () => {
     });
 
     it('should fetch and return a specific version', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => mockVersionData,
-      });
+      mockGet.mockResolvedValue(createMockRestResponse(200, mockVersionData));
 
       (tr.evaluateVersions as jest.Mock).mockReturnValue('1.9.0');
       (tl.debug as jest.Mock).mockImplementation(() => {});
@@ -99,10 +105,7 @@ describe('opentofu', () => {
     });
 
     it('should throw error when version is not found', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => mockVersionData,
-      });
+      mockGet.mockResolvedValue(createMockRestResponse(200, mockVersionData));
 
       (tr.evaluateVersions as jest.Mock).mockReturnValue(null);
       (tl.debug as jest.Mock).mockImplementation(() => {});
@@ -111,37 +114,57 @@ describe('opentofu', () => {
       await expect(getOpenTofuVersion('99.99.99')).rejects.toThrow();
     });
 
-    it('should throw error when fetch fails', async () => {
-      (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+    it('should throw error when HTTP request fails', async () => {
+      mockGet.mockRejectedValue(new Error('Network error'));
       (tl.debug as jest.Mock).mockImplementation(() => {});
-      (tl.loc as jest.Mock).mockImplementation((key: string) => key);
+      (tl.loc as jest.Mock).mockImplementation(
+        (key: string, ...args: string[]) => `${key}: ${args.join(', ')}`
+      );
 
-      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Failed to fetch OpenTofu version API');
+      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Error_FetchFailed');
     });
 
-    it('should throw error when API returns non-ok status', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-      });
+    it('should throw error when API returns non-ok status (RestClient throws)', async () => {
+      const httpError = new Error('Failed request: (500)');
+      (httpError as any).statusCode = 500;
+      mockGet.mockRejectedValue(httpError);
       (tl.debug as jest.Mock).mockImplementation(() => {});
-      (tl.loc as jest.Mock).mockImplementation((key: string) => key);
+      (tl.loc as jest.Mock).mockImplementation(
+        (key: string, ...args: string[]) => `${key}: ${args.join(', ')}`
+      );
 
-      await expect(getOpenTofuVersion('latest')).rejects.toThrow('OpenTofu version API returned status 404');
+      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Error_FetchFailed');
     });
 
-    it('should throw error when JSON parsing fails', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => {
-          throw new Error('Invalid JSON');
-        },
-      });
+    it('should throw error when API returns null result (e.g., 404 Not Found)', async () => {
+      mockGet.mockResolvedValue(createMockRestResponse(404, null));
       (tl.debug as jest.Mock).mockImplementation(() => {});
-      (tl.loc as jest.Mock).mockImplementation((key: string) => key);
+      (tl.loc as jest.Mock).mockImplementation(
+        (key: string, ...args: string[]) => `${key}: ${args.join(', ')}`
+      );
 
-      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Failed to parse OpenTofu version API response');
+      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Error_InvalidApiResponse');
+    });
+
+    it('should throw error when API response has no versions', async () => {
+      mockGet.mockResolvedValue(createMockRestResponse(200, {} as any));
+      (tl.debug as jest.Mock).mockImplementation(() => {});
+      (tl.loc as jest.Mock).mockImplementation(
+        (key: string, ...args: string[]) => `${key}: ${args.join(', ')}`
+      );
+
+      await expect(getOpenTofuVersion('latest')).rejects.toThrow('Error_InvalidApiResponse');
+    });
+
+    it('should use tl.loc for debug message when fetching version info', async () => {
+      mockGet.mockResolvedValue(createMockRestResponse(200, mockVersionData));
+      (tr.evaluateVersions as jest.Mock).mockReturnValue('1.10.2');
+      (tl.debug as jest.Mock).mockImplementation(() => {});
+      (tl.loc as jest.Mock).mockImplementation((key: string, value: string) => `${key}: ${value}`);
+
+      await getOpenTofuVersion('latest');
+
+      expect(tl.loc).toHaveBeenCalledWith('Debug_FetchingVersionInfo', 'https://get.opentofu.org/tofu/api.json');
     });
   });
 

--- a/buildAndReleaseTask/UseOpenTofuV0/opentofu.ts
+++ b/buildAndReleaseTask/UseOpenTofuV0/opentofu.ts
@@ -3,15 +3,30 @@ import * as tr from 'azure-pipelines-tool-lib/tool';
 import * as utils from "./utils";
 import * as path from 'path';
 import * as fs from 'fs';
+import { RestClient, IRestResponse } from 'typed-rest-client/RestClient';
+import { IRequestOptions } from 'typed-rest-client/Interfaces';
 
 interface VersionInfo {
     id: string;
     files: string[];
 }
 
+interface VersionApiResponse {
+    versions: VersionInfo[];
+}
+
 interface ResolvedVersion {
     version: string;
     files: string[];
+}
+
+function createRestClient(): RestClient {
+    const requestOptions: IRequestOptions = {
+        allowRetries: true,
+        maxRetries: 3
+    };
+
+    return new RestClient('opentofu-pipeline-task', undefined, [], requestOptions);
 }
 
 /**
@@ -120,28 +135,21 @@ const getMatchingVersion = (versions: string[], requestedVersion: string): strin
 }
 
 const getVersionInfo = async (url: string): Promise<VersionInfo[]> => {
-    let response;
+    tl.debug(tl.loc("Debug_FetchingVersionInfo", url));
+
+    const client = createRestClient();
+    let response: IRestResponse<VersionApiResponse>;
     try {
-        response = await fetch(url);
+        response = await client.get<VersionApiResponse>(url);
     } catch (error) {
-        const errorMessage = `Failed to fetch OpenTofu version API: ${error instanceof Error ? error.message : String(error)}`;
-        throw new Error(errorMessage);
+        throw new Error(tl.loc("Error_FetchFailed", url, error instanceof Error ? error.message : String(error)));
     }
 
-    if (!response.ok) {
-        const errorMessage = `OpenTofu version API returned status ${response.status}: ${response.statusText}`;
-        throw new Error(errorMessage);
+    if (!response.result?.versions) {
+        throw new Error(tl.loc("Error_InvalidApiResponse", url));
     }
 
-    let data;
-    try {
-        data = await response.json();
-    } catch (error) { 
-        const errorMessage = `Failed to parse OpenTofu version API response: ${error instanceof Error ? error.message : String(error)}`;
-        throw new Error(errorMessage);
-    }
-
-    return data.versions;
+    return response.result.versions;
 }
 
 const getDownloadUrl = (version: string, archiveFileName: string) : string => 

--- a/buildAndReleaseTask/UseOpenTofuV0/package-lock.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.1",
-        "azure-pipelines-tool-lib": "^2.0.10"
+        "azure-pipelines-tool-lib": "^2.0.10",
+        "typed-rest-client": "^1.8.11"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -51,6 +52,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1952,6 +1954,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3030,6 +3033,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4945,6 +4949,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/buildAndReleaseTask/UseOpenTofuV0/package.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/JasonWhall/opentofu-pipeline-task#readme",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.2.1",
-    "azure-pipelines-tool-lib": "^2.0.10"
+    "azure-pipelines-tool-lib": "^2.0.10",
+    "typed-rest-client": "^1.8.11"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/buildAndReleaseTask/UseOpenTofuV0/task.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/task.json
@@ -34,7 +34,10 @@
         "Error_ToolNotFound": "The OpenTofu Cli tool was not found at the expected path: %s. Please check the installation.",
         "Error_VersionNotFound": "The requested version of OpenTofu Cli: %s was not found. Please check the version number.",
         "Error_NoMatchingFile": "No matching archive file found for platform: %s and architecture: %s. The version may not be available for this platform.",
+        "Error_FetchFailed": "Failed to fetch OpenTofu version API at %s: %s",
+        "Error_InvalidApiResponse": "OpenTofu version API at %s returned an invalid or empty response.",
         "Debug_VersionRequested": "Version requested: %s",
-        "Debug_InstallingVersion": "Installing OpenTofu Cli version: %s"
+        "Debug_InstallingVersion": "Installing OpenTofu Cli version: %s",
+        "Debug_FetchingVersionInfo": "Fetching OpenTofu version info from %s"
     }
 }


### PR DESCRIPTION
- Replace native fetch() with typed-rest-client RestClient for version API
- RestClient auto-deserialises JSON to typed VersionApiResponse object
- Configure retries (3 retries)
- Add typed-rest-client as explicit dependency
- Use tl.loc() for all messages with keys in task.json:
  - Debug_FetchingVersionInfo, Error_FetchFailed, Error_InvalidApiResponse
- Update tests to mock RestClient with typed IRestResponse objects
- 38 tests pass, build succeeds