### PR TITLE
feat: typescript 6 upgrade

### DIFF
--- a/.pipelines/ci.yaml
+++ b/.pipelines/ci.yaml
@@ -78,7 +78,7 @@ stages:
         extensionVisibility: private
 
     - task: PackageAzureDevOpsExtension@5
-      displayName: Package Private'
+      displayName: Package Private
       inputs:
         rootFolder: $(Build.SourcesDirectory)
         outputPath: $(Build.ArtifactStagingDirectory)\opentofu-pipeline-task-private.vsix
@@ -120,10 +120,10 @@ stages:
             artifact: vsix
             patterns: "**/*-private.vsix"
 
-          - task: NodeTool@0
-            displayName: Install Node
+          - task: UseNode@1
+            displayName: Install node
             inputs:
-              versionSpec: $(nodeVersion)
+              version: $(nodeVersion)
 
           - task: TfxInstaller@5
             displayName: Install Tfx
@@ -162,10 +162,10 @@ stages:
             artifact: vsix
             patterns: "**/*-public.vsix"
 
-          - task: NodeTool@0
+          - task: UseNode@1
+            displayName: Install node
             inputs:
-              versionSpec: $(nodeVersion)
-            displayName: Install Node
+              version: $(nodeVersion)
 
           - task: TfxInstaller@5
             displayName: Install Tfx

--- a/buildAndReleaseTask/UseOpenTofuV0/jest.config.js
+++ b/buildAndReleaseTask/UseOpenTofuV0/jest.config.js
@@ -2,6 +2,13 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        types: ['node', 'jest'],
+      },
+    }],
+  },
   roots: ['<rootDir>'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   collectCoverageFrom: [

--- a/buildAndReleaseTask/UseOpenTofuV0/package-lock.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^24.10.1",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4944,9 +4944,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/buildAndReleaseTask/UseOpenTofuV0/package.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/package.json
@@ -32,6 +32,6 @@
     "@types/node": "^24.10.1",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.5",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.0"
   }
 }

--- a/buildAndReleaseTask/UseOpenTofuV0/tsconfig.json
+++ b/buildAndReleaseTask/UseOpenTofuV0/tsconfig.json
@@ -109,7 +109,8 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
+    "types": ["node"]                                    /* TS6 defaults types to []; explicitly include node types. */
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
- Bump typescript from ^5.9.3 to ^6.0.0
- Update tsconfig to work with globals for jest
- Remove deprecated CI task
